### PR TITLE
Feature/gh 4 failed to generate a dita website export when running on Windows

### DIFF
--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/DitaProject.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/DitaProject.groovy
@@ -179,8 +179,8 @@ class DitaProject {
 
             topicHrefs.each {key, path ->
                 String href = "${path}${FILE_SEPARATOR}${key}.dita"
-                if(href.startsWith(FILE_SEPARATOR)) {
-                    href = href.replaceFirst(FILE_SEPARATOR, "")
+                while (href.startsWith(FILE_SEPARATOR)) {
+                    href = href.substring(1)    // (replaceFirst() with an unescaped backslash gets gnarly)
                 }
                 if(useTopicsFolder) {
                     href = "..${FILE_SEPARATOR}topics${FILE_SEPARATOR}" + href
@@ -204,8 +204,8 @@ class DitaProject {
 
             mapHrefs.each {key, path ->
                 String href = "${path}${FILE_SEPARATOR}${key}.ditamap"
-                if(href.startsWith(FILE_SEPARATOR)) {
-                    href = href.replaceFirst(FILE_SEPARATOR, "")
+                while (href.startsWith(FILE_SEPARATOR)) {
+                    href = href.substring(1)
                 }
                 keyDef(
                         keys: [key],


### PR DESCRIPTION
The fix is to simply strip off the leading path separators directly and avoid the `replaceFirst()` method which would have required escaping the backslash (if a backslash was being used)