### PR TITLE
Tweak unzip path to work on Linux

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2020-2024 University of Oxford and NHS England
+Copyright 2020-2025 University of Oxford and NHS England
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/DitaAttributeSpecification.groovy
+++ b/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/DitaAttributeSpecification.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/DitaElementSpecification.groovy
+++ b/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/DitaElementSpecification.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/DocumentationParser.groovy
+++ b/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/DocumentationParser.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/PrettyPrintEbnfVisitor.groovy
+++ b/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/PrettyPrintEbnfVisitor.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/SetContainmentEbnfVisitor.groovy
+++ b/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/SetContainmentEbnfVisitor.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/SpecificationParser.groovy
+++ b/src/generation/groovy/uk/ac/ox/softeng/maurodatamapper/dita/generation/SpecificationParser.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/DitaProject.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/DitaProject.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/DitaProjectOptions.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/DitaProjectOptions.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/ArchitecturalAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/ArchitecturalAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/CommonMapElementsAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/CommonMapElementsAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/ComplexTableAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/ComplexTableAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/DataElementAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/DataElementAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/DateAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/DateAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/DebugAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/DebugAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/DisplayAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/DisplayAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/IdAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/IdAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/KeyRefAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/KeyRefAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/KeysAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/KeysAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/LinkRelationshipAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/LinkRelationshipAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/LocalizationAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/LocalizationAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/MetadataAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/MetadataAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/OutputClassAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/OutputClassAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/SimpleTableAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/SimpleTableAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/SpecializationAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/SpecializationAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/TopicRefElementAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/TopicRefElementAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/UniversalAttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/attributes/UniversalAttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Align.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Align.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Cascade.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Cascade.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/CollectionType.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/CollectionType.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/ConAction.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/ConAction.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Dir.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Dir.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/DitaEnum.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/DitaEnum.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Expanse.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Expanse.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Frame.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Frame.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Importance.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Importance.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Linking.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Linking.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/LockTitle.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/LockTitle.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Print.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Print.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/ProcessingRole.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/ProcessingRole.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/RowHeader.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/RowHeader.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Scale.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Scale.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Scope.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Scope.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Search.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Search.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Status.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Status.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Toc.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Toc.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Translate.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/Translate.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/VAlign.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/enums/VAlign.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/helpers/HtmlHelper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/helpers/HtmlHelper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/helpers/IdHelper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/helpers/IdHelper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/helpers/SimpleTableHelper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/helpers/SimpleTableHelper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/AttributeGroup.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/AttributeGroup.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/DitaElement.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/DitaElement.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/DitaElementList.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/DitaElementList.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/HtmlElement.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/HtmlElement.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/SpaceSeparatedStringList.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/SpaceSeparatedStringList.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/TextElement.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/TextElement.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/TextualDitaContent.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/TextualDitaContent.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/ValidatableDitaComponent.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/meta/ValidatableDitaComponent.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/processor/DitaProcessor.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/processor/DitaProcessor.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,6 +184,7 @@ class DitaProcessor {
         try {
             JarFile jarFile = jarConnection.getJarFile()
             String jarConnectionEntryName = jarConnection.getEntryName()
+            if (!jarConnectionEntryName.endsWith('/')) jarConnectionEntryName += '/'
             /**
              * Iterate all entries in the jar file.
              */
@@ -197,7 +198,7 @@ class DitaProcessor {
                 if (jarEntryName.startsWith(jarConnectionEntryName)) {
                     // The jarEntryName is always in Linux path format (even when running in Windows)
                     // so use "/" in the replacement search.
-                    String filename = jarEntryName.replace("${jarConnectionEntryName}/", '')
+                    String filename = jarEntryName.replace(jarConnectionEntryName, '')
                     // The first entry is the "jarConnectionEntryName/" which is the "root" directory of what we want
                     if (filename) {
                         Path destinationPath = destDir.resolve(filename)

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/processor/ZipFileVisitor.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/dita/processor/ZipFileVisitor.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/uk/ac/ox/softeng/dita/helpers/HtmlHelperSpec.groovy
+++ b/src/test/groovy/uk/ac/ox/softeng/dita/helpers/HtmlHelperSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/uk/ac/ox/softeng/dita/helpers/IdHelperSpec.groovy
+++ b/src/test/groovy/uk/ac/ox/softeng/dita/helpers/IdHelperSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/uk/ac/ox/softeng/dita/processor/DitaProcessorSpec.groovy
+++ b/src/test/groovy/uk/ac/ox/softeng/dita/processor/DitaProcessorSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/uk/ac/ox/softeng/dita/test/Test.groovy
+++ b/src/test/groovy/uk/ac/ox/softeng/dita/test/Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/uk/ac/ox/softeng/dita/test/TidySpecification.groovy
+++ b/src/test/groovy/uk/ac/ox/softeng/dita/test/TidySpecification.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/uk/ac/ox/softeng/dita/test/XmlGenerationSpec.groovy
+++ b/src/test/groovy/uk/ac/ox/softeng/dita/test/XmlGenerationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 University of Oxford and NHS England
+ * Copyright 2020-2025 University of Oxford and NHS England
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
In the Ubuntu containers the PDF generation was failing due to a path issue, have tested this branch and it works on both macOS and Linux. Update is in `DitaProcessory.groovy`.

Also updates copyright notice dates.